### PR TITLE
Feature: Add ssdeep searcher

### DIFF
--- a/src/endpoints/searcher.rs
+++ b/src/endpoints/searcher.rs
@@ -15,7 +15,10 @@ async fn search_all(
 ) -> WebResponse<web::Json<Vec<Document>>> {
     let elastic = cxt.get_cxt().read().await;
     let es_parameters = &form.0;
-    search_documents(&elastic, es_parameters, &["*"]).await
+    let build_query_fn = |params: &SearchParameters| -> Value {
+        build_search_query(params)
+    };
+    search_documents(&elastic, es_parameters, &["*"], &build_query_fn).await
 }
 
 #[post("/search/{bucket_names}")]
@@ -27,17 +30,49 @@ async fn search_target(
     let elastic = cxt.get_cxt().read().await;
     let es_parameters = &form.0;
     let indexes: Vec<&str> = path.split(',').collect();
-    search_documents(&elastic, es_parameters, indexes.as_slice()).await
+    let build_query_fn = |params: &SearchParameters| -> Value {
+        build_search_query(params)
+    };
+    search_documents(&elastic, es_parameters, indexes.as_slice(), &build_query_fn).await
+}
+
+#[post("/search-similar")]
+async fn search_similar_docs(
+    cxt: web::Data<SearchContext>,
+    form: web::Json<SearchParameters>,
+) -> WebResponse<web::Json<Vec<Document>>> {
+    let elastic = cxt.get_cxt().read().await;
+    let es_parameters = &form.0;
+    let build_query_fn = |params: &SearchParameters| -> Value {
+        build_search_similar_query(params)
+    };
+    search_documents(&elastic, es_parameters, &["*"], &build_query_fn).await
+}
+
+#[post("/search-similar/{bucket_names}")]
+async fn search_similar_docs_target(
+    cxt: web::Data<SearchContext>,
+    path: web::Path<String>,
+    form: web::Json<SearchParameters>,
+) -> WebResponse<web::Json<Vec<Document>>> {
+    let elastic = cxt.get_cxt().read().await;
+    let es_parameters = &form.0;
+    let indexes: Vec<&str> = path.split(',').collect();
+    let build_query_fn = |params: &SearchParameters| -> Value {
+        build_search_similar_query(params)
+    };
+    search_documents(&elastic, es_parameters, indexes.as_slice(), &build_query_fn).await
 }
 
 async fn search_documents(
     elastic: &Elasticsearch,
     es_parameters: &SearchParameters,
     indexes: &[&str],
+    build_query_fn: &dyn Fn(&SearchParameters) -> Value,
 ) -> WebResponse<web::Json<Vec<Document>>> {
     let result_size = es_parameters.result_size;
     let result_offset = es_parameters.result_offset;
-    let body_value = build_search_query(es_parameters);
+    let body_value = build_query_fn(es_parameters);
     let response_result = elastic
         .search(SearchParts::Index(indexes))
         .from(result_offset)
@@ -106,6 +141,25 @@ fn build_search_query(parameters: &SearchParameters) -> Value {
             "bool": {
                 "must": match_value,
                 "filter": common_filter
+            }
+        }
+    })
+}
+
+fn build_search_similar_query(parameters: &SearchParameters) -> Value {
+    let ssdeep_hash = &parameters.query;
+    println!("Need find by this: {:?}", ssdeep_hash);
+    json!({
+        "query": {
+            "more_like_this" : {
+                "fields" : [
+                    "entity_data",
+                    "document_ssdeep_hash",
+                ],
+                "like" : ssdeep_hash,
+                "min_doc_freq": 1,
+                "min_term_freq" : 1,
+                "max_query_terms" : 25,
             }
         }
     })

--- a/src/es_client.rs
+++ b/src/es_client.rs
@@ -1,7 +1,7 @@
 use crate::endpoints::buckets::{all_buckets, delete_bucket, get_bucket, new_bucket};
 use crate::endpoints::clusters::{all_clusters, delete_cluster, get_cluster, new_cluster};
 use crate::endpoints::documents::{delete_document, get_document, new_document, update_document};
-use crate::endpoints::searcher::{search_all, search_target};
+use crate::endpoints::searcher::{search_all, search_similar_docs, search_similar_docs_target, search_target};
 
 use actix_web::{web, Scope};
 use dotenv::dotenv;
@@ -46,6 +46,8 @@ pub fn build_service() -> Scope {
         .service(get_document)
         .service(search_target)
         .service(search_all)
+        .service(search_similar_docs)
+        .service(search_similar_docs_target)
 }
 
 pub struct ServiceParameters {


### PR DESCRIPTION
There are following changes on `feat/add-ssdeep-seacher`:
 - add endpoints of ssdeep searcher for finding similar documents;
 - add new endpoints to client.